### PR TITLE
Feature/RCC-4 enable temporarily adjust data fetching speed

### DIFF
--- a/example/src/screens/CameraScreen.tsx
+++ b/example/src/screens/CameraScreen.tsx
@@ -42,6 +42,7 @@ export const CameraScreen = () => {
         camera.setFocusMode('spot').then(() => camera.refreshDisplay());
       }
     });
+    camera.setPollIntervalTemporarily(800, 2);
   };
   // #endregion
 

--- a/src/Poller.ts
+++ b/src/Poller.ts
@@ -1,0 +1,100 @@
+/**
+ * Poller provides a simple utility for repeatedly executing a function
+ * at a fixed interval. It supports:
+ * - Starting and stopping polling.
+ * - Permanently changing the interval.
+ * - Temporarily changing the interval for a limited number of cycles,
+ *   after which it automatically reverts to the default.
+ *
+ * Example:
+ * ```ts
+ * const poller = new Poller(() => console.log("tick"), 1000);
+ * poller.start();                // Run every 1s
+ * poller.setIntervalMs(500);     // Change interval to 0.5s
+ * poller.setIntervalTemporarily(200, 5); // Run every 200ms for 5 cycles, then revert
+ * poller.stop();                 // Stop polling
+ * ```
+ */
+export class Poller {
+  private intervalId: ReturnType<typeof setInterval> | null = null;
+  private currentInterval: number;
+
+  /**
+   * Creates a Poller instance to repeatedly run a function at a given interval.
+   * @param fn - The function to execute on each polling cycle.
+   * @param defaultInterval - The default polling interval in milliseconds.
+   */
+  constructor(
+    private fn: () => void,
+    private defaultInterval: number
+  ) {
+    this.currentInterval = defaultInterval;
+  }
+
+  /**
+   * Start polling using the current interval.
+   * If polling is already active, it restarts the poller.
+   */
+  start(): void {
+    this.clear();
+    this.intervalId = setInterval(this.fn, this.currentInterval);
+  }
+
+  /**
+   * Stop polling immediately and clear any active interval.
+   */
+  stop(): void {
+    this.clear();
+  }
+
+  /**
+   * Permanently change the polling interval.
+   * If polling is currently active, it restarts with the new interval.
+   * @param ms - The new interval in milliseconds.
+   */
+  setIntervalMs(ms: number): void {
+    this.currentInterval = ms;
+    if (this.intervalId) {
+      this.start(); // restart with new interval
+    }
+  }
+
+  /**
+   * Temporarily set a different polling interval for a limited number of cycles.
+   * After the specified number of cycles, the poller automatically reverts
+   * to the default interval.
+   *
+   * @param ms - Temporary interval in milliseconds.
+   * @param cycles - Number of times to run at the temporary interval before reverting.
+   * @throws Error if `cycles` is not a positive integer.
+   */
+  setIntervalTemporarily(ms: number, cycles: number): void {
+    if (!Number.isInteger(cycles) || cycles < 1) {
+      throw new Error(
+        `"cycles" must be an integer greater than or equal to 1. Received: ${cycles}`
+      );
+    }
+
+    let count = 0;
+    this.clear();
+
+    this.intervalId = setInterval(() => {
+      this.fn();
+      count++;
+      if (count >= cycles) {
+        this.setIntervalMs(this.defaultInterval);
+      }
+    }, ms);
+  }
+
+  /**
+   * Clear the currently active polling interval, if any.
+   * This is a private utility method used internally by start/stop.
+   */
+  private clear(): void {
+    if (this.intervalId) {
+      clearInterval(this.intervalId);
+      this.intervalId = null;
+    }
+  }
+}

--- a/src/adapters/GR2Adapter.ts
+++ b/src/adapters/GR2Adapter.ts
@@ -389,6 +389,29 @@ class GR2Adapter extends EventEmitter implements IRicohCameraController {
   stopListeningToEvents(): void {
     this._poller.stop();
   }
+
+  /**
+   * Sets the polling interval for fetching data.
+   * Delegates to the underlying Poller to restart with the new interval if active.
+   *
+   * @param ms - New polling interval in milliseconds
+   */
+  setPollInterval(ms: number): void {
+    this._poller.setIntervalMs(ms);
+  }
+
+  /**
+   * Temporarily changes the polling interval for fetching data
+   * for a fixed number of cycles before reverting to the default.
+   * Delegates to the underlying Poller to restart with the new interval if active.
+   *
+   * @param ms - Temporary polling interval in milliseconds
+   * @param cycles - Number of polling cycles to run at the temporary interval
+   * @throws If `cycles` is not an integer ≥ 1
+   */
+  setPollIntervalTemporarily(ms: number, cycles: number): void {
+    this._poller.setIntervalTemporarily(ms, cycles);
+  }
   // #endregion
 }
 

--- a/src/adapters/GR2Adapter.ts
+++ b/src/adapters/GR2Adapter.ts
@@ -10,13 +10,14 @@ import type {
 import { findDifferences, hasAnyKey, type Difference } from '../utils';
 import { FOCUS_MODE_TO_COMMAND_MAP, GR_COMMANDS } from '../Constants';
 import { EVENT_KEY_MAP } from '../eventMap';
+import { Poller } from '../Poller';
 export { GR_COMMANDS, FOCUS_MODE_TO_COMMAND_MAP };
 export type { IRicohCameraController, IDeviceInfo, ICaptureSettings }; // Explicitly import and re-export it
 
 class GR2Adapter extends EventEmitter implements IRicohCameraController {
   private readonly BASE_URL = 'http://192.168.0.1';
   private readonly DEFAULT_TIMEOUT_MS = 1000;
-  private _intervalId: NodeJS.Timeout | null = null;
+  private _poller: Poller;
   private _apiClient: AxiosInstance;
   private _isConnected: boolean = false;
   private _cachedDeviceInfo: IDeviceInfo | null;
@@ -38,7 +39,8 @@ class GR2Adapter extends EventEmitter implements IRicohCameraController {
       timeout: this.DEFAULT_TIMEOUT_MS,
     });
 
-    this.startListeningToEvents();
+    this._poller = new Poller(() => this.fetchData(), 2000);
+    this._poller.start(); // this.startListeningToEvents();
   }
 
   // #region Getter methods to expose the variables
@@ -378,23 +380,14 @@ class GR2Adapter extends EventEmitter implements IRicohCameraController {
    * Starts the polling process to periodically check for updates.
    */
   startListeningToEvents(): void {
-    if (this._intervalId == null) {
-      this.fetchData();
-
-      this._intervalId = setInterval(() => {
-        this.fetchData();
-      }, 2000);
-    }
+    this._poller.start();
   }
 
   /**
    * Stops the periodic updates when they are no longer needed.
    */
   stopListeningToEvents(): void {
-    if (this._intervalId) {
-      clearInterval(this._intervalId);
-      this._intervalId = null;
-    }
+    this._poller.stop();
   }
   // #endregion
 }

--- a/src/adapters/GR3Adapter.ts
+++ b/src/adapters/GR3Adapter.ts
@@ -424,6 +424,29 @@ class GR3Adapter extends EventEmitter implements IRicohCameraController {
   stopListeningToEvents(): void {
     this._poller.stop();
   }
+
+  /**
+   * Sets the polling interval for fetching data.
+   * Delegates to the underlying Poller to restart with the new interval if active.
+   *
+   * @param ms - New polling interval in milliseconds
+   */
+  setPollInterval(ms: number): void {
+    this._poller.setIntervalMs(ms);
+  }
+
+  /**
+   * Temporarily changes the polling interval for fetching data
+   * for a fixed number of cycles before reverting to the default.
+   * Delegates to the underlying Poller to restart with the new interval if active.
+   *
+   * @param ms - Temporary polling interval in milliseconds
+   * @param cycles - Number of polling cycles to run at the temporary interval
+   * @throws If `cycles` is not an integer ≥ 1
+   */
+  setPollIntervalTemporarily(ms: number, cycles: number): void {
+    this._poller.setIntervalTemporarily(ms, cycles);
+  }
   // #endregion
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -423,6 +423,29 @@ class RicohCameraController
   stopListeningToEvents(): void {
     this.safeAdapter.stopListeningToEvents();
   }
+
+  /**
+   * Sets the polling interval for fetching data.
+   * Delegates to the underlying Poller to restart with the new interval if active.
+   *
+   * @param ms - New polling interval in milliseconds
+   */
+  setPollInterval(ms: number): void {
+    this.safeAdapter.setPollInterval(ms);
+  }
+
+  /**
+   * Temporarily changes the polling interval for fetching data
+   * for a fixed number of cycles before reverting to the default.
+   * Delegates to the underlying Poller to restart with the new interval if active.
+   *
+   * @param ms - Temporary polling interval in milliseconds
+   * @param cycles - Number of polling cycles to run at the temporary interval
+   * @throws If `cycles` is not an integer ≥ 1
+   */
+  setPollIntervalTemporarily(ms: number, cycles: number): void {
+    this.safeAdapter.setPollIntervalTemporarily(ms, cycles);
+  }
   // #endregion
 }
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -4,6 +4,8 @@ import type { GR_COMMANDS } from './Constants';
 export interface IRicohCameraController extends EventEmitter {
   startListeningToEvents(): void;
   stopListeningToEvents(): void;
+  setPollInterval(ms: number): void;
+  setPollIntervalTemporarily(ms: number, cycles: number): void;
   get isConnected(): boolean;
   get info(): IDeviceInfo | null;
   get captureSettings(): ICaptureSettings | null;


### PR DESCRIPTION
## Summary
This PR enhances the GR2Adapter and GR3Adapter to support dynamic polling interval changes by delegating to the shared Poller utility. 
It enables the system to temporarily switch to a faster polling rate to retrieve near real‑time updates 
(e.g., lens focus state success/failure) during critical moments, 
and then automatically revert to the normal polling interval once those moments have passed.

It introduces two new public methods:
- setPollInterval(ms: number) — Permanently updates the polling interval.
- setPollIntervalTemporarily(ms: number, cycles: number) — Temporarily changes the polling interval for a fixed number of cycles before reverting to the default.


## Changes
- Created `Poller.ts` for flexible polling intervals.
- Updated `index.tsx`, `interfaces.ts`, `GR2Adapter.ts` and `GR3Adapter.ts` to add setPollInterval() and setPollIntervalTemporarily() to allow adjusting polling interval.
- Updated the example app to test temporary polling interval changing feature.

## Testing
- Test on Android and iOS devices
- Run the example app with an updated handleCameraDisplayTouch()
- Connect to GR II and GR III cameras
- Confirm default polling interval works as before.
- Tap to focus and verify data fetches every 800ms for 2 cycles.
- Confirm interval reverts to default after 2 cycles.