### PR TITLE
docs/RCC-9 Move function descriptions to the interface class

### DIFF
--- a/src/adapters/GR2Adapter.ts
+++ b/src/adapters/GR2Adapter.ts
@@ -45,23 +45,14 @@ class GR2Adapter extends EventEmitter implements IRicohCameraController {
 
   // #region Getter methods to expose the variables
 
-  /**
-   * Indicates whether a camera is currently connected.
-   * @returns {boolean} `true` if a camera is connected. Otherwise, returns `false`
-   */
   get isConnected(): boolean {
     return this._isConnected;
   }
 
   /**
-   * Retrieves the cached device information.
-   *
-   * This function returns the stored device information, which is intended
+   * Returns the stored device information, which is intended
    * to be a cached copy of data fetched from the camera.
    * Accessing this cache avoids redundant computations or network requests.
-   *
-   * @returns {IDeviceInfo | null} The cached device information. Returns `null` if no
-   * device information is currently cached.
    */
   get info(): IDeviceInfo | null {
     return this._cachedDeviceInfo;
@@ -88,11 +79,6 @@ class GR2Adapter extends EventEmitter implements IRicohCameraController {
   }
 
   // #region Camera Status
-  /**
-   * Get camera status
-   *
-   * @returns {Promise<any>} A promise that resolves with an object containing camera status.
-   */
   async getStatus(): Promise<any> {
     const response = await this._apiClient.get('/v1/ping');
     return response.data;
@@ -101,17 +87,6 @@ class GR2Adapter extends EventEmitter implements IRicohCameraController {
 
   // #region Lens Focus Controls
 
-  /**
-   * Locks the camera focus at a specific area within the frame.
-   *
-   * This function instructs the camera to focus on a specific point in the frame,
-   * where `x` and `y` are expressed as percentages (0 to 100) of the frame's width and height.
-   * For example, (50, 50) would lock focus at the center of the frame.
-   *
-   * @param x - The horizontal percentage (0 to 100) representing the focus point in the frame.
-   * @param y - The vertical percentage (0 to 100) representing the focus point in the frame.
-   * @returns A promise that resolves when the focus is successfully locked.
-   */
   async lockFocus(x: number, y: number): Promise<any> {
     // Validation: Value Constraints
     // Throw an error if `x` or `y` is outside the range of 0 to 100.
@@ -148,23 +123,17 @@ class GR2Adapter extends EventEmitter implements IRicohCameraController {
 
   // #endregion
 
-  // #region Capture Settings
-  /**
-   * Retrieves the current capture settings of the camera.
-   *
-   * @returns {Promise<any>} A promise that resolves with an object containing capture settings.
-   */
+  // #region Camera Properties & Settings
+  async getAllProperties(): Promise<any> {
+    const response = await this._apiClient.get('/v1/props');
+    return response.data;
+  }
+
   async getCaptureSettings(): Promise<any> {
     const response = await this._apiClient.get('/v1/params');
     return response.data;
   }
 
-  /**
-   * Sets the capture settings of the camera.
-   *
-   * @param {Record<string, any>} settings - An object containing the capture settings to be applied.
-   * @returns {Promise<any>} A promise that resolves when the settings are successfully applied.
-   */
   async setCaptureSettings(settings: Record<string, any>): Promise<any> {
     // Convert the object to a query-like string
     const rawData = Object.entries(settings)
@@ -176,98 +145,41 @@ class GR2Adapter extends EventEmitter implements IRicohCameraController {
     return response.data;
   }
 
-  /**
-   * Retrieves the list of dial modes of the camera.
-   *
-   * @returns {string[]} The list of focus modes.
-   */
   getDialModeList(): (string | null)[] {
     return ['Auto', 'P', 'AV', 'TV', 'TAV', 'M', 'MOV', 'MY3', 'MY2', 'MY1'];
   }
 
-  /**
-   * Sets the dial mode.
-   *
-   * @param {string} mode - Dial mode name.
-   * @returns {Promise<any>} A promise that resolves when the settings are successfully applied.
-   */
   setDialMode(mode: string): Promise<any> {
     if (mode === 'MOV') mode = 'movie';
     return this.sendCommand(`cmd=bdial ${mode}`);
   }
 
-  /**
-   * Retrieves the list of drive modes of the camera.
-   *
-   * @returns {string[]} The list of drive modes.
-   */
   getDriveModeList() {
     return ['single', 'intervalComp', 'interval', 'continuous', 'bracket'];
   }
 
-  /**
-   * Retrieves the currently selected drive mode.
-   *
-   * @returns The name of the current drive mode (e.g., "single", "continuous").
-   * @throws Error not supported.
-   */
   getDriveMode(): string {
     throw new Error('getDriveMode() is not supported on Ricoh GR II');
   }
 
-  /**
-   * Returns the list of supported self-timer options for the selected drive mode.
-   *
-   * @returns An array of timer option keys (e.g. "off", "2s", "10s") supported by the selected drive mode.
-   * @throws Error not supported.
-   * Example:
-   * ```ts
-   * getSelfTimerOptionList(); // ["off", "2s", "10s"]
-   * ```
-   */
   getSelfTimerOptionList(): string[] {
     throw new Error('getSelfTimerOptionList() is not supported on Ricoh GR II');
   }
 
-  /**
-   * Retrieves the currently selected self-timer option.
-   *
-   * @returns {string} The current self-timer option (e.g., "off", "2s", "10s").
-   * @throws Error not supported.
-   */
   getSelfTimerOption(): string {
     throw new Error('getSelfTimerOption() is not supported on Ricoh GR II');
   }
 
-  /**
-   * Sets the shoot mode / drive mode / self timer.
-   *
-   * @param {string} _driveMode - Drive mode.
-   * @param {string} _selfTimerOption - Self-timer option.
-   * @returns {Promise<any>} A promise that resolves when the settings are successfully applied.
-   * @throws Error not supported.
-   */
   setShootMode(_driveMode: string, _selfTimerOption: string): Promise<any> {
     return Promise.reject(
       new Error('setShootMode() is not supported on Ricoh GR II')
     );
   }
 
-  /**
-   * Retrieves the list of focus modes of the camera.
-   *
-   * @returns {string[]} The list of focus modes.
-   */
   getFocusModeList() {
     return Object.keys(FOCUS_MODE_TO_COMMAND_MAP);
   }
 
-  /**
-   * Sets the focus mode.
-   *
-   * @param {string} mode - Focus mode name.
-   * @returns {Promise<any>} A promise that resolves when the settings are successfully applied.
-   */
   setFocusMode(mode: string): Promise<any> {
     const command = Object.entries(FOCUS_MODE_TO_COMMAND_MAP).find(
       ([key, _]) => key === mode
@@ -279,34 +191,16 @@ class GR2Adapter extends EventEmitter implements IRicohCameraController {
       return Promise.reject(new Error('Invalid focus mode'));
     }
   }
+
   // #endregion
 
-  // #region Camera Settings
+  // #region Others
 
-  /**
-   * Retrieve all the properties of the device.
-   *
-   * @returns {Promise<any>} A promise that resolves with an object containing the device properties.
-   */
-  async getAllProperties(): Promise<any> {
-    const response = await this._apiClient.get('/v1/props');
-    return response.data;
-  }
-  // #endregion
-
-  // #region Camera Display
-
-  /**
-   * Send a command to the device.
-   *
-   * @returns {Promise<any>} A promise that resolves with an object containing the device properties.
-   */
   async sendCommand(command: string | GR_COMMANDS): Promise<any> {
     const response = await this._apiClient.post('/_gr', command);
     return response.data;
   }
 
-  // Force refresh the display
   async refreshDisplay(): Promise<any> {
     const rawData = 'cmd=mode refresh';
     const response = await this._apiClient.post('/_gr', rawData);

--- a/src/adapters/GR3Adapter.ts
+++ b/src/adapters/GR3Adapter.ts
@@ -50,24 +50,14 @@ class GR3Adapter extends EventEmitter implements IRicohCameraController {
   }
 
   // #region Getter methods to expose the variables
-
-  /**
-   * Indicates whether a camera is currently connected.
-   * @returns {boolean} `true` if a camera is connected. Otherwise, returns `false`
-   */
   get isConnected(): boolean {
     return this._isConnected;
   }
 
   /**
-   * Retrieves the cached device information.
-   *
-   * This function returns the stored device information, which is intended
+   * Returns the stored device information, which is intended
    * to be a cached copy of data fetched from the camera.
    * Accessing this cache avoids redundant computations or network requests.
-   *
-   * @returns {IDeviceInfo | null} The cached device information. Returns `null` if no
-   * device information is currently cached.
    */
   get info(): IDeviceInfo | null {
     return this._cachedDeviceInfo;
@@ -94,11 +84,6 @@ class GR3Adapter extends EventEmitter implements IRicohCameraController {
   }
 
   // #region Camera Status
-  /**
-   * Get camera status
-   *
-   * @returns {Promise<any>} A promise that resolves with an object containing camera status.
-   */
   async getStatus(): Promise<any> {
     const response = await this._apiClient.get('/v1/ping');
     return response.data;
@@ -107,17 +92,6 @@ class GR3Adapter extends EventEmitter implements IRicohCameraController {
 
   // #region Lens Focus Controls
 
-  /**
-   * Locks the camera focus at a specific area within the frame.
-   *
-   * This function instructs the camera to focus on a specific point in the frame,
-   * where `x` and `y` are expressed as percentages (0 to 100) of the frame's width and height.
-   * For example, (50, 50) would lock focus at the center of the frame.
-   *
-   * @param x - The horizontal percentage (0 to 100) representing the focus point in the frame.
-   * @param y - The vertical percentage (0 to 100) representing the focus point in the frame.
-   * @returns A promise that resolves when the focus is successfully locked.
-   */
   async lockFocus(x: number, y: number): Promise<any> {
     // Validation: Value Constraints
     // Throw an error if `x` or `y` is outside the range of 0 to 100.
@@ -141,14 +115,6 @@ class GR3Adapter extends EventEmitter implements IRicohCameraController {
 
   // #region Capture Controls
 
-  /**
-   * Captures a photo, optionally with x, y coordinates
-   *
-   * @param {number | null} x The x-coordinate of the photo. If null, coordinates are not specified.
-   * @param {number | null} y The y-coordinate of the photo. If null, coordinates are not specified.
-   * @returns {Promise<any>} A promise that resolves with the response data from the camera API.
-   * @throws {Error} If there is an error during the API request.
-   */
   async capturePhoto(x: number | null, y: number | null): Promise<any> {
     if (x != null && y != null) {
       const rawData = `pos=${x},${y}&af=on`;
@@ -162,23 +128,18 @@ class GR3Adapter extends EventEmitter implements IRicohCameraController {
 
   // #endregion
 
-  // #region Capture Settings
-  /**
-   * Retrieves the current capture settings of the camera.
-   *
-   * @returns {Promise<any>} A promise that resolves with an object containing capture settings.
-   */
+  // #region Camera Properties & Settings
+
+  async getAllProperties(): Promise<any> {
+    const response = await this._apiClient.get('/v1/props');
+    return response.data;
+  }
+
   async getCaptureSettings(): Promise<any> {
     const response = await this._apiClient.get('/v1/props');
     return response.data;
   }
 
-  /**
-   * Sets the capture settings of the camera.
-   *
-   * @param {Record<string, any>} settings - An object containing the capture settings to be applied.
-   * @returns {Promise<any>} A promise that resolves when the settings are successfully applied.
-   */
   async setCaptureSettings(settings: Record<string, any>): Promise<any> {
     // Convert the object to a query-like string
     const rawData = Object.entries(settings)
@@ -189,40 +150,18 @@ class GR3Adapter extends EventEmitter implements IRicohCameraController {
     return response.data;
   }
 
-  /**
-   * Retrieves the list of dial modes of the camera.
-   *
-   * @returns {string[]} The list of focus modes.
-   */
   getDialModeList(): (string | null)[] {
     return ['U3', 'U2', 'U1', 'P', 'AV', 'TV', 'M', null];
   }
 
-  /**
-   * Sets the dial mode.
-   *
-   * @param {string} mode - Dial mode name.
-   * @returns {Promise<any>} A promise that resolves when the settings are successfully applied.
-   */
   setDialMode(mode: string): Promise<any> {
     return this.sendCommand(`cmd=bdial ${mode}`);
   }
 
-  /**
-   * Retrieves the list of drive modes of the camera.
-   *
-   * @returns {string[]} The list of drive modes.
-   */
   getDriveModeList(): string[] {
     return Object.keys(shootModeLookup) as (keyof typeof shootModeLookup)[];
   }
 
-  /**
-   * Retrieves the currently selected drive mode.
-   *
-   * @returns The name of the current drive mode (e.g., "single", "continuous").
-   * @throws Error if the shoot mode is not found.
-   */
   getDriveMode(): DriveMode {
     const shootMode = this._cachedDeviceInfo?.shootMode;
     if (shootMode !== undefined) {
@@ -231,28 +170,11 @@ class GR3Adapter extends EventEmitter implements IRicohCameraController {
       throw new Error(`Shoot mode "${shootMode}" not found.`);
     }
   }
-
-  /**
-   * Returns the list of supported self-timer options for the selected drive mode.
-   *
-   * @returns An array of timer option keys (e.g. "off", "2s", "10s") supported by the selected drive mode.
-   *
-   * Example:
-   * ```ts
-   * getSelfTimerOptionList(); // ["off", "2s", "10s"]
-   * ```
-   */
   getSelfTimerOptionList(): string[] {
     const driveMode = this.getDriveMode();
     return Object.keys(shootModeLookup[driveMode]) as TimerOption<DriveMode>[];
   }
 
-  /**
-   * Retrieves the currently selected self-timer option.
-   *
-   * @returns {string} The current self-timer option (e.g., "off", "2s", "10s").
-   * @throws Error if the shoot mode is not found.
-   */
   getSelfTimerOption(): string {
     const shootMode = this._cachedDeviceInfo?.shootMode;
     if (shootMode !== undefined) {
@@ -262,13 +184,6 @@ class GR3Adapter extends EventEmitter implements IRicohCameraController {
     }
   }
 
-  /**
-   * Sets the shoot mode / drive mode / self timer.
-   *
-   * @param {DriveMode} driveMode - Drive mode.
-   * @param {TimerOption} selfTimerOption - Self-timer option.
-   * @returns {Promise<any>} A promise that resolves when the settings are successfully applied.
-   */
   setShootMode<D extends DriveMode, T extends TimerOption<D>>(
     driveMode: D,
     selfTimerOption: T
@@ -286,21 +201,10 @@ class GR3Adapter extends EventEmitter implements IRicohCameraController {
     }
   }
 
-  /**
-   * Retrieves the list of focus modes of the camera.
-   *
-   * @returns {string[]} The list of focus modes.
-   */
   getFocusModeList() {
     return Object.keys(FOCUS_MODE_TO_COMMAND_MAP);
   }
 
-  /**
-   * Sets the focus mode.
-   *
-   * @param {string} mode - Focus mode name.
-   * @returns {Promise<any>} A promise that resolves when the settings are successfully applied.
-   */
   setFocusMode(mode: string): Promise<any> {
     const command = Object.entries(FOCUS_MODE_TO_COMMAND_MAP).find(
       ([key, _]) => key === mode
@@ -314,32 +218,18 @@ class GR3Adapter extends EventEmitter implements IRicohCameraController {
   }
   // #endregion
 
-  // #region Camera Settings
+  // #region Others
 
-  /**
-   * Retrieve all the properties of the device.
-   *
-   * @returns {Promise<any>} A promise that resolves with an object containing the device properties.
-   */
-  async getAllProperties(): Promise<any> {
-    const response = await this._apiClient.get('/v1/props');
-    return response.data;
-  }
-  // #endregion
-
-  // #region Camera Display
-
-  /**
-   * Send a command to the device.
-   *
-   * @returns {Promise<any>} A promise that resolves with an object containing the device properties.
-   */
   async sendCommand(command: string | GR_COMMANDS): Promise<any> {
     const response = await this._apiClient.post('/_gr', command);
     return response.data;
   }
 
-  // Force refresh the display
+  /**
+   * Force refresh the display.
+   *
+   * @throws This function is not supported on Ricoh GR III
+   */
   async refreshDisplay(): Promise<any> {
     return Promise.reject(
       new Error('refreshDisplay() is not supported on Ricoh GR III')

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -98,6 +98,11 @@ class RicohCameraController
   // #endregion
 
   // #region Adapter: Event Forwarding
+  /**
+   * Subscribes and forwards all the events from the adapter events to the consumers.
+   *
+   * @param {string[]} events - List of event names to forward (e.g., from CameraEvents).
+   */
   private forwardAdapterEvents(events: string[]) {
     for (const event of events) {
       const handler = (...args: any[]) => {
@@ -108,6 +113,9 @@ class RicohCameraController
     }
   }
 
+  /**
+   * Removes all previously registered adapter event listeners and clears the list.
+   */
   private cleanupListeners() {
     for (const { event, handler } of this.adapterListeners) {
       this.adapter?.off(event, handler);
@@ -138,26 +146,12 @@ class RicohCameraController
   }
   // #endregion
 
-  // #region Getter methods to expose the variables
+  // #region Delegates - Getter methods to expose variables
 
-  /**
-   * Indicates whether a camera is currently connected.
-   * @returns {boolean} `true` if a camera is connected. Otherwise, returns `false`
-   */
   get isConnected(): boolean {
     return this.adapter !== null && this.adapter.isConnected;
   }
 
-  /**
-   * Retrieves the cached device information.
-   *
-   * This function returns the stored device information, which is intended
-   * to be a cached copy of data fetched from the camera.
-   * Accessing this cache avoids redundant computations or network requests.
-   *
-   * @returns {IDeviceInfo | null} The cached device information. Returns `null` if no
-   * device information is currently cached.
-   */
   get info(): IDeviceInfo | null {
     if (this.adapter === null) {
       return null;
@@ -165,16 +159,6 @@ class RicohCameraController
     return this.adapter.info;
   }
 
-  /**
-   * Retrieves the cached capture settings.
-   *
-   * This function returns the stored capture settings, which are intended
-   * to be a cached copy of settings obtained from the camera.
-   * Accessing this cache avoids redundant computations or external calls.
-   *
-   * @returns {ICaptureSettings | null} The cached capture settings. Returns `null` if no
-   * capture settings are currently cached.
-   */
   get captureSettings(): ICaptureSettings | null {
     if (this.adapter === null) {
       return null;
@@ -184,49 +168,20 @@ class RicohCameraController
 
   // #endregion
 
+  // #region Delegates the command to the detected adapter
+
   getLiveViewURL(): string {
     return this.safeAdapter.getLiveViewURL();
   }
 
-  // #region Camera Status
-  /**
-   * Get camera status
-   *
-   * @returns {Promise<any>} A promise that resolves with an object containing camera status.
-   */
   async getStatus(): Promise<any> {
     return this.safeAdapter.getStatus();
   }
-  // #endregion
 
-  // #region Lens Focus Controls
-
-  /**
-   * Locks the camera focus at a specific area within the frame.
-   *
-   * This function instructs the camera to focus on a specific point in the frame,
-   * where `x` and `y` are expressed as percentages (0 to 100) of the frame's width and height.
-   * For example, (50, 50) would lock focus at the center of the frame.
-   *
-   * @param x - The horizontal percentage (0 to 100) representing the focus point in the frame.
-   * @param y - The vertical percentage (0 to 100) representing the focus point in the frame.
-   * @returns A promise that resolves when the focus is successfully locked.
-   */
   async lockFocus(x: number, y: number): Promise<any> {
     return this.safeAdapter.lockFocus(x, y);
   }
 
-  // #endregion
-
-  // #region Capture Controls
-
-  /**
-   * Captures a photo using provided coordinates.
-   *
-   * @param {number | null} x The x-coordinate (optional).
-   * @param {number | null} y The y-coordinate (optional).
-   * @returns {Promise<any>} A promise resolving with the result of the capture.
-   */
   async capturePhoto(
     x: number | null = null,
     y: number | null = null
@@ -234,128 +189,50 @@ class RicohCameraController
     return this.safeAdapter.capturePhoto(x, y);
   }
 
-  // #endregion
-
-  // #region Capture Settings
-  /**
-   * Retrieves the current capture settings of the camera.
-   *
-   * @returns {Promise<any>} A promise that resolves with an object containing capture settings.
-   */
   async getCaptureSettings(): Promise<any> {
     return this.safeAdapter.getCaptureSettings();
   }
 
-  /**
-   * Sets the capture settings of the camera.
-   *
-   * @param {Record<string, any>} settings - An object containing the capture settings to be applied.
-   * @returns {Promise<any>} A promise that resolves when the settings are successfully applied.
-   */
   async setCaptureSettings(settings: Record<string, any>): Promise<any> {
     return this.safeAdapter.setCaptureSettings(settings);
   }
 
-  /**
-   * Retrieves the list of dial modes of the camera.
-   *
-   * @returns {string[]} The list of focus modes.
-   */
   getDialModeList(): (string | null)[] {
     return this.safeAdapter.getDialModeList();
   }
 
-  /**
-   * Sets the dial mode.
-   *
-   * @param {string} mode - Dial mode name.
-   * @returns {Promise<any>} A promise that resolves when the settings are successfully applied.
-   */
   setDialMode(mode: string): Promise<any> {
     return this.safeAdapter.setDialMode(mode);
   }
 
-  /**
-   * Retrieves the list of drive modes of the camera.
-   *
-   * @returns {string[]} The list of drive modes.
-   */
   getDriveModeList(): string[] {
     return this.safeAdapter.getDriveModeList();
   }
 
-  /**
-   * Retrieves the currently selected drive mode.
-   *
-   * @returns The name of the current drive mode (e.g., "single", "continuous").
-   * @throws Error if the shoot mode is not found.
-   */
   getDriveMode(): string {
     return this.safeAdapter.getDriveMode();
   }
 
-  /**
-   * Returns the list of supported self-timer options for the selected drive mode.
-   *
-   * @returns An array of timer option keys (e.g. "off", "2s", "10s") supported by the selected drive mode.
-   *
-   * Example:
-   * ```ts
-   * getSelfTimerOptionList(); // ["off", "2s", "10s"]
-   * ```
-   */
   getSelfTimerOptionList(): string[] {
     return this.safeAdapter.getSelfTimerOptionList();
   }
 
-  /**
-   * Retrieves the currently selected self-timer option.
-   *
-   * @returns {string} The current self-timer option (e.g., "off", "2s", "10s").
-   * @throws Error if the shoot mode is not found.
-   */
   getSelfTimerOption(): string {
     return this.safeAdapter.getSelfTimerOption();
   }
 
-  /**
-   * Sets the shoot mode / drive mode / self timer.
-   *
-   * @param {string} driveMode - Drive mode.
-   * @param {string} selfTimerOption - Self-timer option.
-   * @returns {Promise<any>} A promise that resolves when the settings are successfully applied.
-   */
   setShootMode(driveMode: string, selfTimerOption: string): Promise<any> {
     return this.safeAdapter.setShootMode(driveMode, selfTimerOption);
   }
 
-  /**
-   * Retrieves the list of focus modes of the camera.
-   *
-   * @returns {string[]} The list of focus modes.
-   */
   getFocusModeList() {
     return this.safeAdapter.getFocusModeList();
   }
 
-  /**
-   * Sets the focus mode.
-   *
-   * @param {string} mode - Focus mode name.
-   * @returns {Promise<any>} A promise that resolves when the settings are successfully applied.
-   */
   setFocusMode(mode: string): Promise<any> {
     return this.safeAdapter.setFocusMode(mode);
   }
-  // #endregion
 
-  // #region Camera Settings
-
-  /**
-   * Retrieve all the properties of the device.
-   *
-   * @returns {Promise<any>} A promise that resolves with an object containing the device properties.
-   */
   async getAllProperties(): Promise<any> {
     try {
       const response = await this._apiClient.get('/v1/props');
@@ -364,15 +241,7 @@ class RicohCameraController
       throw error;
     }
   }
-  // #endregion
 
-  // #region Camera Display
-
-  /**
-   * Send a command to the device.
-   *
-   * @returns {Promise<any>} A promise that resolves with an object containing the device properties.
-   */
   async sendCommand(command: string | GR_COMMANDS): Promise<any> {
     try {
       const response = await this._apiClient.post('/_gr', command);
@@ -382,7 +251,6 @@ class RicohCameraController
     }
   }
 
-  // Force refresh the display
   async refreshDisplay(): Promise<any> {
     try {
       const rawData = 'cmd=mode refresh';
@@ -410,42 +278,22 @@ class RicohCameraController
     }
   }
 
-  /**
-   * Starts the polling process to periodically check for updates.
-   */
   startListeningToEvents(): void {
     this.safeAdapter.startListeningToEvents();
   }
 
-  /**
-   * Stops the periodic updates when they are no longer needed.
-   */
   stopListeningToEvents(): void {
     this.safeAdapter.stopListeningToEvents();
   }
 
-  /**
-   * Sets the polling interval for fetching data.
-   * Delegates to the underlying Poller to restart with the new interval if active.
-   *
-   * @param ms - New polling interval in milliseconds
-   */
   setPollInterval(ms: number): void {
     this.safeAdapter.setPollInterval(ms);
   }
 
-  /**
-   * Temporarily changes the polling interval for fetching data
-   * for a fixed number of cycles before reverting to the default.
-   * Delegates to the underlying Poller to restart with the new interval if active.
-   *
-   * @param ms - Temporary polling interval in milliseconds
-   * @param cycles - Number of polling cycles to run at the temporary interval
-   * @throws If `cycles` is not an integer ≥ 1
-   */
   setPollIntervalTemporarily(ms: number, cycles: number): void {
     this.safeAdapter.setPollIntervalTemporarily(ms, cycles);
   }
+
   // #endregion
 }
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -2,30 +2,202 @@ import { EventEmitter } from 'events';
 import type { GR_COMMANDS } from './Constants';
 
 export interface IRicohCameraController extends EventEmitter {
+  /**
+   * Starts the polling process to periodically check for updates.
+   */
   startListeningToEvents(): void;
+
+  /**
+   * Stops the periodic updates when they are no longer needed.
+   */
   stopListeningToEvents(): void;
+
+  /**
+   * Sets the polling interval for fetching data.
+   *
+   * @param ms - New polling interval in milliseconds
+   */
   setPollInterval(ms: number): void;
+
+  /**
+   * Temporarily changes the polling interval for fetching data
+   * for a fixed number of cycles before reverting to the default.
+   *
+   * @param ms - Temporary polling interval in milliseconds
+   * @param cycles - Number of polling cycles to run at the temporary interval
+   * @throws If `cycles` is not an integer ≥ 1
+   */
   setPollIntervalTemporarily(ms: number, cycles: number): void;
+
+  /**
+   * Indicates whether a camera is currently connected.
+   * @returns {boolean} `true` if a camera is connected. Otherwise, returns `false`
+   */
   get isConnected(): boolean;
+
+  /**
+   * Retrieves the cached device information.
+   *
+   * @returns {IDeviceInfo | null} The cached device information. Returns `null` if no
+   * device information is currently cached.
+   */
   get info(): IDeviceInfo | null;
+
+  /**
+   * Retrieves the cached capture settings.
+   *
+   * @returns {ICaptureSettings | null} The cached capture settings. Returns `null` if no
+   * capture settings are currently cached.
+   */
   get captureSettings(): ICaptureSettings | null;
+
+  /**
+   * Returns the URL for the live view stream.
+   *
+   * @returns {string} The full URL for accessing the live view endpoint.
+   */
   getLiveViewURL(): string;
+
+  /**
+   * Get camera status
+   *
+   * @returns {Promise<any>} A promise that resolves with an object containing camera status.
+   */
   getStatus(): Promise<any>;
+
+  /**
+   * Retrieves the list of dial modes of the camera.
+   *
+   * @returns {string[]} The list of focus modes.
+   */
   getDialModeList(): (string | null)[];
+
+  /**
+   * Sets the dial mode.
+   *
+   * @param {string} mode - Dial mode name.
+   * @returns {Promise<any>} A promise that resolves when the settings are successfully applied.
+   */
   setDialMode(mode: string): Promise<any>;
+
+  /**
+   * Retrieves the list of drive modes of the camera.
+   *
+   * @returns {string[]} The list of drive modes.
+   */
   getDriveModeList(): string[];
+
+  /**
+   * Retrieves the currently selected drive mode.
+   *
+   * @returns The name of the current drive mode (e.g., "single", "continuous").
+   * @throws Error if the shoot mode is not found.
+   */
   getDriveMode(): string;
+
+  /**
+   * Returns the list of supported self-timer options for the selected drive mode.
+   *
+   * @returns An array of timer option keys (e.g. "off", "2s", "10s") supported by the selected drive mode.
+   *
+   * Example:
+   * ```ts
+   * getSelfTimerOptionList(); // ["off", "2s", "10s"]
+   * ```
+   */
   getSelfTimerOptionList(): string[];
+
+  /**
+   * Retrieves the currently selected self-timer option.
+   *
+   * @returns {string} The current self-timer option (e.g., "off", "2s", "10s").
+   * @throws Error if the shoot mode is not found.
+   */
   getSelfTimerOption(): string;
+
+  /**
+   * Sets the shoot mode / drive mode / self timer.
+   *
+   * @param {string} driveMode - Drive mode.
+   * @param {string} selfTimerOption - Self-timer option.
+   * @returns {Promise<any>} A promise that resolves when the settings are successfully applied.
+   */
   setShootMode(driveMode: string, selfTimerOption: string): Promise<any>;
+
+  /**
+   * Retrieves the list of focus modes of the camera.
+   *
+   * @returns {string[]} The list of focus modes.
+   */
   getFocusModeList(): string[];
+
+  /**
+   * Sets the focus mode.
+   *
+   * @param {string} mode - Focus mode name.
+   * @returns {Promise<any>} A promise that resolves when the settings are successfully applied.
+   */
   setFocusMode(mode: string): Promise<any>;
+
+  /**
+   * Locks the camera focus at a specific area within the frame.
+   *
+   * This function instructs the camera to focus on a specific point in the frame,
+   * where `x` and `y` are expressed as percentages (0 to 100) of the frame's width and height.
+   * For example, (50, 50) would lock focus at the center of the frame.
+   *
+   * @param x - The horizontal percentage (0 to 100) representing the focus point in the frame.
+   * @param y - The vertical percentage (0 to 100) representing the focus point in the frame.
+   * @returns A promise that resolves when the focus is successfully locked.
+   */
   lockFocus(x: number, y: number): Promise<any>;
+
+  /**
+   * Captures a photo using provided coordinates.
+   *
+   * @param {number | null} x The x-coordinate (optional).
+   * @param {number | null} y The y-coordinate (optional).
+   * @returns {Promise<any>} A promise resolving with the result of the capture.
+   */
   capturePhoto(x: number | null, y: number | null): Promise<any>;
+
+  /**
+   * Retrieves the current capture settings of the camera.
+   *
+   * @returns {Promise<any>} A promise that resolves with an object containing capture settings.
+   */
   getCaptureSettings(): Promise<any>;
+
+  /**
+   * Sets the capture settings of the camera.
+   *
+   * @param {Record<string, any>} settings - An object containing the capture settings to be applied.
+   * @returns {Promise<any>} A promise that resolves when the settings are successfully applied.
+   */
   setCaptureSettings(settings: Record<string, any>): Promise<any>;
+
+  /**
+   * Retrieve all the properties of the device.
+   *
+   * @returns {Promise<any>} A promise that resolves with an object containing the device properties.
+   */
   getAllProperties(): Promise<any>;
+
+  /**
+   * Force refresh the camera display.
+   * Useful when the camera display is out of sync after changing certain settings.
+   *
+   * Supported device: Ricoh GR II only.
+   *
+   * @returns A promise that resolves once the refresh operation is complete.
+   */
   refreshDisplay(): Promise<any>;
+
+  /**
+   * Send a command to the device.
+   *
+   * @returns {Promise<any>} A promise that resolves with an object containing the device properties.
+   */
   sendCommand(command: string | GR_COMMANDS): Promise<any>;
 }
 


### PR DESCRIPTION
## Summary
This PR moves function documentation from `index.tsx`, `GR2Adapter.ts`, and `GR3Adapter.ts` to the interface. 
The goal is to improve abstraction, ensure documentation is visible at the point of use, and reduce duplication between interface and implementation.

## Changes
- Added function documentation to `interfaces.ts`.
- Removed most of function documentation from `index.tsx`.
- Removed most of function documentation from `GR2Adapter.ts`.
- Removed most of function documentation from `GR3Adapter.ts`.