### PR TITLE
Feature/RCC-10 add getFocusSetting() method to the adapters

### DIFF
--- a/example/src/screens/CameraScreen.tsx
+++ b/example/src/screens/CameraScreen.tsx
@@ -338,6 +338,16 @@ export const CameraScreen = () => {
                 .catch((error) => handleError(error));
             }}
           />
+          <Button
+            title="getFocusSetting()"
+            onPress={() => {
+              try {
+                Alert.alert(camera.getFocusSetting());
+              } catch (err) {
+                handleError(err);
+              }
+            }}
+          />
         </View>
       </ScrollView>
     </SafeAreaView>

--- a/src/adapters/GR2Adapter.ts
+++ b/src/adapters/GR2Adapter.ts
@@ -192,6 +192,14 @@ class GR2Adapter extends EventEmitter implements IRicohCameraController {
     }
   }
 
+  getFocusSetting() {
+    const value = this._cachedDeviceInfo?.AFMode;
+    if (value !== undefined) {
+      return value;
+    }
+    throw new Error('Focus Setting is not available');
+  }
+
   // #endregion
 
   // #region Others

--- a/src/adapters/GR3Adapter.ts
+++ b/src/adapters/GR3Adapter.ts
@@ -216,6 +216,15 @@ class GR3Adapter extends EventEmitter implements IRicohCameraController {
       return Promise.reject(new Error('Invalid focus mode'));
     }
   }
+
+  getFocusSetting() {
+    const value = this._cachedDeviceInfo?.focusSetting;
+    if (value !== undefined) {
+      return value;
+    }
+    throw new Error('Focus Setting is not available');
+  }
+
   // #endregion
 
   // #region Others

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -233,6 +233,10 @@ class RicohCameraController
     return this.safeAdapter.setFocusMode(mode);
   }
 
+  getFocusSetting(): string {
+    return this.safeAdapter.getFocusSetting();
+  }
+
   async getAllProperties(): Promise<any> {
     try {
       const response = await this._apiClient.get('/v1/props');

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -140,6 +140,14 @@ export interface IRicohCameraController extends EventEmitter {
   setFocusMode(mode: string): Promise<any>;
 
   /**
+   * Retrieves the current of focus setting of the camera.
+   * (e.g., "multiauto", "spot", "pinpoint", "snap", "inf").
+   *
+   * @returns {string} The current focus setting.
+   */
+  getFocusSetting(): string;
+
+  /**
    * Locks the camera focus at a specific area within the frame.
    *
    * This function instructs the camera to focus on a specific point in the frame,
@@ -289,7 +297,17 @@ export interface ICaptureSettings {
   stillSize: string;
   movieSize: string;
   focusMode: string;
+
+  /** Focus setting (e.g., "multiauto", "spot", "pinpoint", "snap", "inf").
+   *
+   * Supported devices: GRII*/
   AFMode: string;
+
+  /** Focus setting (e.g., "multiauto", "spot", "pinpoint", "snap", "inf").
+   *
+   * Supported devices: GRIII & GR IIIx */
+  focusSetting: string;
+
   ssid: string;
   key: string;
   channel: number;


### PR DESCRIPTION
## Summary
This PR implements the getFocusSetting method in the Adapter class to allow compatibility between the GR II  and the GR III response data from the API.

Each device returns the response data in a different format. The Adapter should abstract away these differences and provide a consistent focusSetting value to the application.

GR II response data:
``{
 "focusMode" : "AF",
 "AFMode" : "spot",
}``

GR III response data:
``{
 "focusMode": "af",
 "focusSetting": "spot",
}``

## Changes
- Added `getFocusSetting()` to `interfaces.ts`.
- Implemented `getFocusSetting()` in `GR2Adapter.ts`.
- Implemented `getFocusSetting()` in `GR3Adapter.ts`.
- Added `getFocusSetting()` to `RicohCameraController` class in `index.tsx` and delegates the command to the detected adapter.
- Update the example app to add a button for testing `getFocusSetting()`

## Testing
- Launch the example app on Android and iOS devices.
- Connect to a GR II and GR III cameras.
- Tap on the button `getFocusSetting`.
- Confirm the alert box shows the same Focus Setting value as the camera.