### PR TITLE
fix/RCC-13 Refactor sendCommand() and refreshDisplay() to Use Safe Adapter 

### DIFF
--- a/example/src/screens/CameraScreen.tsx
+++ b/example/src/screens/CameraScreen.tsx
@@ -167,7 +167,7 @@ export const CameraScreen = () => {
                 .then((data) => {
                   setTextInputValue(JSON.stringify(data, null, 4));
                 })
-                .catch((error) => setTextInputValue(error));
+                .catch(handleError);
 
               const endTime = performance.now();
               setText(`${endTime - startTime}ms`);
@@ -179,43 +179,43 @@ export const CameraScreen = () => {
           <Button
             title="Capture photo"
             onPress={() => {
-              camera.capturePhoto();
+              camera.capturePhoto().catch(handleError);
             }}
           />
           <Button
             title="lens_focus: 20,20"
             onPress={() => {
-              camera.lockFocus(20, 20);
+              camera.lockFocus(20, 20).catch(handleError);
             }}
           />
           <Button
             title="ISO 400"
             onPress={() => {
-              camera.setCaptureSettings({ sv: 400 });
+              camera.setCaptureSettings({ sv: 400 }).catch(handleError);
             }}
           />
           <Button
             title="ISO auto"
             onPress={() => {
-              camera.setCaptureSettings({ sv: 'auto' });
+              camera.setCaptureSettings({ sv: 'auto' }).catch(handleError);
             }}
           />
           <Button
             title="Shutter Speed: 1/80"
             onPress={() => {
-              camera.setCaptureSettings({ tv: '1.80' });
+              camera.setCaptureSettings({ tv: '1.80' }).catch(handleError);
             }}
           />
           <Button
             title="Shutter Speed: 5s"
             onPress={() => {
-              camera.setCaptureSettings({ tv: '5.1' });
+              camera.setCaptureSettings({ tv: '5.1' }).catch(handleError);
             }}
           />
           <Button
             title="Z-IN"
             onPress={() => {
-              camera.sendCommand(GR_COMMANDS.BUTTON_ZOOM_IN);
+              camera.sendCommand(GR_COMMANDS.BUTTON_ZOOM_IN).catch(handleError);
             }}
           />
         </View>
@@ -241,16 +241,22 @@ export const CameraScreen = () => {
           <Button
             title="xv=+0.3"
             onPress={() => {
-              camera.setCaptureSettings({ xv: '+0.3', sv: '400' });
+              camera
+                .setCaptureSettings({ xv: '+0.3', sv: '400' })
+                .catch(handleError);
             }}
           />
           <Button
             title="FocusModeList"
             onPress={() => {
-              Alert.alert(
-                'List of Focus Modes',
-                camera.getFocusModeList().toString()
-              );
+              try {
+                Alert.alert(
+                  'List of Focus Modes',
+                  camera.getFocusModeList().toString()
+                );
+              } catch (error) {
+                handleError(error);
+              }
             }}
           />
           <Button
@@ -268,7 +274,7 @@ export const CameraScreen = () => {
               camera
                 .setFocusMode('snap')
                 .then(() => Alert.alert('success'))
-                .catch((error) => Alert.alert('ERROR', error.message));
+                .catch(handleError);
             }}
           />
           <Button
@@ -277,7 +283,7 @@ export const CameraScreen = () => {
               camera
                 .setFocusMode('MF')
                 .then(() => Alert.alert('success'))
-                .catch((error) => Alert.alert('ERROR', error.message));
+                .catch(handleError);
             }}
           />
 
@@ -335,7 +341,7 @@ export const CameraScreen = () => {
               camera
                 .setShootMode('continuous', 'off')
                 .then(() => Alert.alert('success'))
-                .catch((error) => handleError(error));
+                .catch(handleError);
             }}
           />
           <Button

--- a/src/adapters/GR2Adapter.ts
+++ b/src/adapters/GR2Adapter.ts
@@ -149,7 +149,7 @@ class GR2Adapter extends EventEmitter implements IRicohCameraController {
     return ['Auto', 'P', 'AV', 'TV', 'TAV', 'M', 'MOV', 'MY3', 'MY2', 'MY1'];
   }
 
-  setDialMode(mode: string): Promise<any> {
+  async setDialMode(mode: string): Promise<any> {
     if (mode === 'MOV') mode = 'movie';
     return this.sendCommand(`cmd=bdial ${mode}`);
   }
@@ -170,7 +170,10 @@ class GR2Adapter extends EventEmitter implements IRicohCameraController {
     throw new Error('getSelfTimerOption() is not supported on Ricoh GR II');
   }
 
-  setShootMode(_driveMode: string, _selfTimerOption: string): Promise<any> {
+  async setShootMode(
+    _driveMode: string,
+    _selfTimerOption: string
+  ): Promise<any> {
     return Promise.reject(
       new Error('setShootMode() is not supported on Ricoh GR II')
     );
@@ -180,7 +183,7 @@ class GR2Adapter extends EventEmitter implements IRicohCameraController {
     return Object.keys(FOCUS_MODE_TO_COMMAND_MAP);
   }
 
-  setFocusMode(mode: string): Promise<any> {
+  async setFocusMode(mode: string): Promise<any> {
     const command = Object.entries(FOCUS_MODE_TO_COMMAND_MAP).find(
       ([key, _]) => key === mode
     );

--- a/src/adapters/GR3Adapter.ts
+++ b/src/adapters/GR3Adapter.ts
@@ -154,7 +154,7 @@ class GR3Adapter extends EventEmitter implements IRicohCameraController {
     return ['U3', 'U2', 'U1', 'P', 'AV', 'TV', 'M', null];
   }
 
-  setDialMode(mode: string): Promise<any> {
+  async setDialMode(mode: string): Promise<any> {
     return this.sendCommand(`cmd=bdial ${mode}`);
   }
 
@@ -184,7 +184,7 @@ class GR3Adapter extends EventEmitter implements IRicohCameraController {
     }
   }
 
-  setShootMode<D extends DriveMode, T extends TimerOption<D>>(
+  async setShootMode<D extends DriveMode, T extends TimerOption<D>>(
     driveMode: D,
     selfTimerOption: T
   ): Promise<any> {
@@ -205,7 +205,7 @@ class GR3Adapter extends EventEmitter implements IRicohCameraController {
     return Object.keys(FOCUS_MODE_TO_COMMAND_MAP);
   }
 
-  setFocusMode(mode: string): Promise<any> {
+  async setFocusMode(mode: string): Promise<any> {
     const command = Object.entries(FOCUS_MODE_TO_COMMAND_MAP).find(
       ([key, _]) => key === mode
     );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -207,7 +207,7 @@ class RicohCameraController
     return this.safeAdapter.getDialModeList();
   }
 
-  setDialMode(mode: string): Promise<any> {
+  async setDialMode(mode: string): Promise<any> {
     return this.safeAdapter.setDialMode(mode);
   }
 
@@ -227,7 +227,7 @@ class RicohCameraController
     return this.safeAdapter.getSelfTimerOption();
   }
 
-  setShootMode(driveMode: string, selfTimerOption: string): Promise<any> {
+  async setShootMode(driveMode: string, selfTimerOption: string): Promise<any> {
     return this.safeAdapter.setShootMode(driveMode, selfTimerOption);
   }
 
@@ -235,7 +235,7 @@ class RicohCameraController
     return this.safeAdapter.getFocusModeList();
   }
 
-  setFocusMode(mode: string): Promise<any> {
+  async setFocusMode(mode: string): Promise<any> {
     return this.safeAdapter.setFocusMode(mode);
   }
 
@@ -249,14 +249,11 @@ class RicohCameraController
   }
 
   async sendCommand(command: string | GR_COMMANDS): Promise<any> {
-    const response = await this._apiClient.post('/_gr', command);
-    return response.data;
+    return this.safeAdapter.sendCommand(command);
   }
 
   async refreshDisplay(): Promise<any> {
-    const rawData = 'cmd=mode refresh';
-    const response = await this._apiClient.post('/_gr', rawData);
-    return response.data;
+    return this.safeAdapter.refreshDisplay();
   }
 
   // #endregion


### PR DESCRIPTION
## Summary
As per RCC-13, this pull request refactors the sendCommand() and refreshDisplay() functions in the RicohCameraController class to delegate function calls to the safeAdapter. This change aims to make our code more modular, maintainable, and decoupled from implementation details.

## Changes
- Updated `sendCommand()` and `refreshDisplay()` in RicohCameraController to use safeAdapter.
- Changed some functions in RicohCameraController, GR2Adapter, and GR3Adapter to async functions