### PR TITLE
Feature/RCC-14 Implement functions to fetch photos

### DIFF
--- a/example/src/screens/CameraScreen.tsx
+++ b/example/src/screens/CameraScreen.tsx
@@ -9,6 +9,7 @@ import {
   SafeAreaView,
   View,
   Dimensions,
+  Image,
 } from 'react-native';
 import { useCameraController } from '../CameraControllerContext';
 import { CameraEvents, type IDeviceInfo } from 'ricoh-camera-controller';
@@ -24,6 +25,7 @@ export const CameraScreen = () => {
   // #region 🔍 Refs
   const cameraDisplayRef = useRef<CameraDisplay>(null);
   const textInputRef = useRef<TextInput>(null);
+  const imageRef = useRef<Image>(null);
   // #endregion
 
   // #region Layout
@@ -52,7 +54,7 @@ export const CameraScreen = () => {
     camera.startListeningToEvents();
 
     setTimeout(() => {
-      cameraDisplayRef.current?.setURL(camera.getLiveViewURL());
+      // cameraDisplayRef.current?.setURL(camera.getLiveViewURL());
     }, 500);
   };
 
@@ -352,6 +354,75 @@ export const CameraScreen = () => {
               } catch (err) {
                 handleError(err);
               }
+            }}
+          />
+          <Button
+            title="getMediaList()"
+            onPress={() => {
+              try {
+                camera
+                  .getMediaList()
+                  .then((data) => {
+                    Alert.alert(JSON.stringify(data, null, 2));
+                  })
+                  .catch(handleError);
+              } catch (err) {
+                handleError(err);
+              }
+            }}
+          />
+
+          <Image ref={imageRef} />
+          <Button
+            title="getResizedPhotoURL('402_0801', 'R0178596.JPG', 'large')"
+            onPress={() => {
+              try {
+                const mediaURL = camera.getResizedPhotoURL(
+                  '402_0801',
+                  'R0178596.JPG',
+                  'large'
+                );
+
+                imageRef.current?.setNativeProps({
+                  source: [{ uri: mediaURL }],
+                  style: [{ width: 400, height: 300 }],
+                });
+              } catch (err) {
+                handleError(err);
+              }
+            }}
+          />
+          <Button
+            title="getOriginalMediaURL('402_0801', 'R0178596.JPG')"
+            onPress={() => {
+              try {
+                const mediaURL = camera.getOriginalMediaURL(
+                  '402_0801',
+                  'R0178596.JPG'
+                );
+
+                imageRef.current?.setNativeProps({
+                  source: [{ uri: mediaURL }],
+                  style: [{ width: 400, height: 300 }],
+                });
+              } catch (err) {
+                handleError(err);
+              }
+            }}
+          />
+
+          <Button
+            title="getMostRecentPhotoURL('large')"
+            onPress={() => {
+              camera
+                .getMostRecentPhotoURL('large')
+                .then((mediaURL) => {
+                  imageRef.current?.setNativeProps({
+                    source: [{ uri: mediaURL }],
+                    style: [{ width: 400, height: 300 }],
+                  });
+                })
+                .catch(handleError);
             }}
           />
         </View>

--- a/src/enums/PhotoSize.ts
+++ b/src/enums/PhotoSize.ts
@@ -1,11 +1,10 @@
 /**
- * Represents the size or format of a media file.
+ * Represents the size of a media file.
  *
  * Possible values:
  * - THUMBNAIL: A thumbnail-sized photo (160 x 120).
  * - SMALL: A small-sized photo (720 x 480).
  * - LARGE: A large-sized photo (1920 x 1280).
- * - ORIGINAL: The original media file (could be JPG, RAW, or video).
  */
 export const PhotoSize = {
   /** A thumbnail-sized photo (160 x 120). */

--- a/src/enums/PhotoSize.ts
+++ b/src/enums/PhotoSize.ts
@@ -1,0 +1,19 @@
+/**
+ * Represents the size or format of a media file.
+ *
+ * Possible values:
+ * - THUMBNAIL: A thumbnail-sized photo (160 x 120).
+ * - SMALL: A small-sized photo (720 x 480).
+ * - LARGE: A large-sized photo (1920 x 1280).
+ * - ORIGINAL: The original media file (could be JPG, RAW, or video).
+ */
+export const PhotoSize = {
+  /** A thumbnail-sized photo (160 x 120). */
+  THUMBNAIL: 'thumbnail',
+  /** A small-sized photo (720 x 480). */
+  SMALL: 'small',
+  /** A large-sized photo (1920 x 1280). */
+  LARGE: 'large',
+} as const;
+
+export type PhotoSize = (typeof PhotoSize)[keyof typeof PhotoSize];

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,6 +11,8 @@ import { FOCUS_MODE_TO_COMMAND_MAP, GR_COMMANDS } from './Constants';
 export { GR_COMMANDS, FOCUS_MODE_TO_COMMAND_MAP };
 export type { IRicohCameraController, IDeviceInfo, ICaptureSettings }; // Explicitly import and re-export it
 import { GR2Adapter, GR3Adapter } from './adapters';
+import type { PhotoSize } from './enums/PhotoSize';
+export * from './enums/PhotoSize';
 
 interface IAdapterListener {
   event: string;
@@ -256,6 +258,25 @@ class RicohCameraController
     return this.safeAdapter.refreshDisplay();
   }
 
+  async getMediaList(): Promise<any> {
+    return this.safeAdapter.getMediaList();
+  }
+
+  getResizedPhotoURL(
+    directory: string,
+    filename: string,
+    size: PhotoSize
+  ): string {
+    return this.safeAdapter.getResizedPhotoURL(directory, filename, size);
+  }
+
+  getMostRecentPhotoURL(size: PhotoSize): Promise<string> {
+    return this.safeAdapter.getMostRecentPhotoURL(size);
+  }
+
+  getOriginalMediaURL(directory: string, filename: string): string {
+    return this.safeAdapter.getOriginalMediaURL(directory, filename);
+  }
   // #endregion
 
   // #region Other Functions

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from 'events';
 import type { GR_COMMANDS } from './Constants';
+import type { PhotoSize } from './enums/PhotoSize';
 
 export interface IRicohCameraController extends EventEmitter {
   /**
@@ -207,6 +208,64 @@ export interface IRicohCameraController extends EventEmitter {
    * @returns {Promise<any>} A promise that resolves with an object containing the device properties.
    */
   sendCommand(command: string | GR_COMMANDS): Promise<any>;
+
+  /**
+   * Retrieves a list of available media files and directories on the camera.
+   *
+   * @returns {Promise<any>} A promise that resolves with an object containing the available media files.
+   */
+  getMediaList(): Promise<any>;
+
+  /**
+   * Retrieves a URL for accessing a compressed photo from the given directory and filename.
+   *
+   * **IMPORTANT NOTES**
+   * - The returned URL will be of a resized JPG photo, not the original full-resolution image.
+   *
+   * **LIMITATIONS**
+   * - For Ricoh GR II cameras, using `PhotoSize.LARGE` is equivalent to using `PhotoSize.SMALL`
+   *    because this camera model does not support generating light-weight large-sized photos.
+   * @param {string} directory - The path to the directory containing the media file.
+   * @param {string} filename - The name of the media file (including extension).
+   * @param {PhotoSize} size - The desired size for the photo ('thumbnail', 'small', or 'large').
+   * @returns {string} A string representing the URL for accessing the resized photo.
+   * 
+   * Example usage:
+   * ```typescript
+    const camera = new RicohCameraController();
+    const imageUrl = camera.getResizedPhotoURL('425_0914', 'R0178820.JPG', PhotoSize.THUMB);
+    console.log(imageUrl); // Output: http://192.168.0.1/v1/photos/425_0914/R0178820.JPG?size=thumb
+   */
+  getResizedPhotoURL(
+    directory: string,
+    filename: string,
+    size: PhotoSize
+  ): string;
+
+  /**
+   * Retrieves the URL for accessing the most recent resized photo in a specific format.
+   *
+   * **IMPORTANT NOTES**
+   * - The returned URL will be of a resized JPG photo, not the original full-resolution image.
+   *
+   * **LIMITATIONS**
+   * - For Ricoh GR II cameras, using `PhotoSize.LARGE` is equivalent to using `PhotoSize.SMALL`
+   *    because this camera model does not support generating light-weight large-sized photos.
+   * @param {PhotoSize} size - The desired size for the photo ('thumbnail', 'small', or 'large').
+   * @returns {string} A string representing the URL for accessing the most recent resized photo.
+   */
+  getMostRecentPhotoURL(size: PhotoSize): Promise<string>;
+
+  /**
+   * Retrieves a URL for accessing an original media file from the given directory and filename.
+   *
+   * **IMPORTANT NOTES**
+   * - The returned URL can be of type JPG, DNG, or video (e.g., MOV).
+   * @param {string} directory - The path to the directory containing the media file.
+   * @param {string} filename - The name of the media file (including extension).
+   * @returns {string} A string representing the URL for accessing the original media file.
+   */
+  getOriginalMediaURL(directory: string, filename: string): string;
 }
 
 export interface IDeviceInfo extends ICaptureSettings {


### PR DESCRIPTION
## Summary
This pull request introduces functions to interact with GR cameras, enabling other apps to seamlessly integrate with cameras and fetch photos.

## Changes
1. Added `PhotoSize.ts` to introduce a new PhotoSize enum to represent the size of a media file.
2. Added four new methods to `IRicohCameraController` interface:
   - getMediaList: Retrieves a list of available media files and directories on the camera.
   - getResizedPhotoURL: Retrieves a URL for accessing a compressed photo from the given directory and filename.
   - getMostRecentPhotoURL: Retrieves a URL for accessing the most recent resized photo in a specific format.
   - getOriginalMediaURL: Retrieves a URL for accessing an original media file from the given directory and filename.
3. Implemented methods in `GR2Adapter`: Implemented the four new methods in the GR2Adapter class:
   - getMediaList.
   - getResizedPhotoURL.
   - getMostRecentPhotoURL.
   - getOriginalMediaURL.
4. Implemented methods in `GR3Adapter`: Implemented the four new methods in the GR2Adapter class:
   - getMediaList.
   - getResizedPhotoURL.
   - getMostRecentPhotoURL.
   - getOriginalMediaURL.
5. Implemented the methods in RicohCameraController: Delegated the calls to GR2Adapter and GR3Adapter.
6. Updated Example App to test the new methods.