### PR TITLE
Refactor/RCC-17 Remove getMostRecentPhotoURL method

### DIFF
--- a/example/src/screens/CameraScreen.tsx
+++ b/example/src/screens/CameraScreen.tsx
@@ -414,15 +414,15 @@ export const CameraScreen = () => {
           <Button
             title="getMostRecentPhotoURL('large')"
             onPress={() => {
-              camera
-                .getMostRecentPhotoURL('large')
-                .then((mediaURL) => {
-                  imageRef.current?.setNativeProps({
-                    source: [{ uri: mediaURL }],
-                    style: [{ width: 400, height: 300 }],
-                  });
-                })
-                .catch(handleError);
+              // camera
+              //   .getMostRecentPhotoURL('large')
+              //   .then((mediaURL) => {
+              //     imageRef.current?.setNativeProps({
+              //       source: [{ uri: mediaURL }],
+              //       style: [{ width: 400, height: 300 }],
+              //     });
+              //   })
+              //   .catch(handleError);
             }}
           />
         </View>

--- a/src/adapters/GR2Adapter.ts
+++ b/src/adapters/GR2Adapter.ts
@@ -250,24 +250,10 @@ class GR2Adapter extends EventEmitter implements IRicohCameraController {
     }
   }
 
-  async getMostRecentPhotoURL(size: PhotoSize): Promise<string> {
-    const url = `${this.BASE_URL}/v1/photos/latest`;
-
-    switch (size) {
-      case PhotoSize.THUMBNAIL:
-        return `${url}?size=thumb`;
-      case PhotoSize.SMALL:
-        return `${url}?size=view`;
-      case PhotoSize.LARGE:
-        // Same MediaType.SMALL due to the limitation of GR II
-        // This camera model does not support generating light-weight large-sized photos.
-        return `${url}?size=view`;
-    }
-  }
-
   getOriginalMediaURL(directory: string, filename: string): string {
     return `${this.BASE_URL}/v1/photos/${directory}/${filename}`;
   }
+
   // #endregion
 
   // #region Helpers

--- a/src/adapters/GR3Adapter.ts
+++ b/src/adapters/GR3Adapter.ts
@@ -275,16 +275,10 @@ class GR3Adapter extends EventEmitter implements IRicohCameraController {
     }
   }
 
-  async getMostRecentPhotoURL(size: PhotoSize): Promise<string> {
-    const mediaList = await this.getMediaList();
-    const lastDir = mediaList.dirs[mediaList.dirs.length - 1];
-    const mostRecentFile = lastDir.files[lastDir.files.length - 1];
-    return this.getResizedPhotoURL(lastDir.name, mostRecentFile, size);
-  }
-
   getOriginalMediaURL(directory: string, filename: string): string {
     return `${this.BASE_URL}/v1/photos/${directory}/${filename}`;
   }
+
   // #endregion
 
   // #region Helpers

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -270,10 +270,6 @@ class RicohCameraController
     return this.safeAdapter.getResizedPhotoURL(directory, filename, size);
   }
 
-  getMostRecentPhotoURL(size: PhotoSize): Promise<string> {
-    return this.safeAdapter.getMostRecentPhotoURL(size);
-  }
-
   getOriginalMediaURL(directory: string, filename: string): string {
     return this.safeAdapter.getOriginalMediaURL(directory, filename);
   }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -243,20 +243,6 @@ export interface IRicohCameraController extends EventEmitter {
   ): string;
 
   /**
-   * Retrieves the URL for accessing the most recent resized photo in a specific format.
-   *
-   * **IMPORTANT NOTES**
-   * - The returned URL will be of a resized JPG photo, not the original full-resolution image.
-   *
-   * **LIMITATIONS**
-   * - For Ricoh GR II cameras, using `PhotoSize.LARGE` is equivalent to using `PhotoSize.SMALL`
-   *    because this camera model does not support generating light-weight large-sized photos.
-   * @param {PhotoSize} size - The desired size for the photo ('thumbnail', 'small', or 'large').
-   * @returns {string} A string representing the URL for accessing the most recent resized photo.
-   */
-  getMostRecentPhotoURL(size: PhotoSize): Promise<string>;
-
-  /**
    * Retrieves a URL for accessing an original media file from the given directory and filename.
    *
    * **IMPORTANT NOTES**


### PR DESCRIPTION
## Summary
This PR removes the getMostRecentPhotoURL method from the library. This change simplifies the library's API and reduces redundant code.
Instead of relying on a specific method to retrieve the most recent photo URL, app developers will need to modify their code to handle this logic themselves.

## Changes
1. Removed getMostRecentPhotoURL() from `interfaces`
2. Removed getMostRecentPhotoURL() from `RicohCameraController`
3. Removed getMostRecentPhotoURL() from `GR2Adapter`
4. Removed getMostRecentPhotoURL() from `GR3Adapter`
5. Disabled  getMostRecentPhoto button in `Example App`