### PR TITLE
Feature/RCC-18 Add IMediaList and IDir interfaces for media directory management

### DIFF
--- a/src/adapters/GR2Adapter.ts
+++ b/src/adapters/GR2Adapter.ts
@@ -6,6 +6,7 @@ import type {
   IRicohCameraController,
   IDeviceInfo,
   ICaptureSettings,
+  IMediaList,
 } from '../interfaces';
 import { findDifferences, hasAnyKey, type Difference } from '../utils';
 import { FOCUS_MODE_TO_COMMAND_MAP, GR_COMMANDS } from '../Constants';
@@ -223,7 +224,7 @@ class GR2Adapter extends EventEmitter implements IRicohCameraController {
 
   // #region Media Files: Photos & Videos
 
-  async getMediaList(): Promise<any> {
+  async getMediaList(): Promise<IMediaList> {
     const response = await this._apiClient.get('/v1/photos');
     if (response.data.errCode === 200) {
       return response.data;

--- a/src/adapters/GR3Adapter.ts
+++ b/src/adapters/GR3Adapter.ts
@@ -6,6 +6,7 @@ import type {
   IRicohCameraController,
   IDeviceInfo,
   ICaptureSettings,
+  IMediaList,
 } from '../interfaces';
 import { findDifferences, hasAnyKey, type Difference } from '../utils';
 import {
@@ -250,7 +251,7 @@ class GR3Adapter extends EventEmitter implements IRicohCameraController {
 
   // #region Media Files: Photos & Videos
 
-  async getMediaList(): Promise<any> {
+  async getMediaList(): Promise<IMediaList> {
     const response = await this._apiClient.get('/v1/photos');
     if (response.data.errCode === 200) {
       return response.data;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,6 +6,7 @@ import type {
   IRicohCameraController,
   IDeviceInfo,
   ICaptureSettings,
+  IMediaList,
 } from './interfaces';
 import { FOCUS_MODE_TO_COMMAND_MAP, GR_COMMANDS } from './Constants';
 export { GR_COMMANDS, FOCUS_MODE_TO_COMMAND_MAP };
@@ -258,7 +259,7 @@ class RicohCameraController
     return this.safeAdapter.refreshDisplay();
   }
 
-  async getMediaList(): Promise<any> {
+  async getMediaList(): Promise<IMediaList> {
     return this.safeAdapter.getMediaList();
   }
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -358,3 +358,28 @@ export interface ICaptureSettings {
   channel: number;
   //   datetime: string; // ISO 8601 formatted date-time string
 }
+
+/**
+ * Represents a single Directory.
+ *
+ * @property {string} name - The name of the directory.
+ * @property {string[]} files - An array of file names in the directory.
+ */
+export interface IDir {
+  /** The name of the directory. */
+  name: string;
+
+  /**  An array of file names in the directory. */
+  files: string[];
+}
+
+/**
+ * Represents a list of media directories.
+ * Each directory in this list contains a list of media files.
+ *
+ * @property {IDir[]} dirs - An array of directory objects.
+ */
+export interface IMediaList {
+  /**  An array of directory objects. */
+  dirs: IDir[];
+}


### PR DESCRIPTION
## Summary
This pull request introduces two new interfaces, IMediaList and IDir, to standardize the representation of media directories and their associated properties.

## Changes
- Added `IMediaList` and `IDir` to `interfaces.ts`.
- Updated `getMediaList()` method signature in `GR2Adapter.ts` to return a `Promise<IMediaList>`.
- Updated `getMediaList()` method signature in `GR3Adapter.ts` to return a `Promise<IMediaList>`.
- Updated `getMediaList()` method signature in `RicohCameraController.ts` to return a `Promise<IMediaList>`.