### PR TITLE
Fix/RCC-30 RAW file preview issues

### DIFF
--- a/src/adapters/gr2/GR2Adapter.ts
+++ b/src/adapters/gr2/GR2Adapter.ts
@@ -308,12 +308,18 @@ class GR2Adapter extends EventEmitter implements IRicohCameraController {
 
     switch (size) {
       case PhotoSize.THUMBNAIL:
-        return `${url}?size=thumb`;
+        if (filename.endsWith('JPG') || filename.endsWith('jpg')) {
+          return `${url}?size=thumb`;
+        } else {
+          // Same as PhotoSize.SMALL due to camera API limitations.
+          // This camera model doesn't support 'thumbnail' size for RAW or VIDEO files.
+          return `${url}?size=view`;
+        }
       case PhotoSize.SMALL:
         return `${url}?size=view`;
       case PhotoSize.LARGE:
-        // Same MediaType.SMALL due to the limitation of GR II
-        // This camera model does not support generating light-weight large-sized photos.
+        // Same as PhotoSize.SMALL due to camera API limitations.
+        // This camera model doesn't support generating light-weight large-sized photos.
         return `${url}?size=view`;
     }
   }

--- a/src/adapters/gr3/GR3Adapter.ts
+++ b/src/adapters/gr3/GR3Adapter.ts
@@ -313,7 +313,13 @@ class GR3Adapter extends EventEmitter implements IRicohCameraController {
       case PhotoSize.SMALL:
         return `${url}?size=view`;
       case PhotoSize.LARGE:
-        return `${url}?size=xs`;
+        if (filename.endsWith('JPG') || filename.endsWith('jpg')) {
+          return `${url}?size=xs`;
+        } else {
+          // Same as PhotoSize.SMALL due to camera API limitations.
+          // This camera model doesn't support 'xs' size for RAW or VIDEO files.
+          return `${url}?size=view`;
+        }
     }
   }
 


### PR DESCRIPTION
## Summary
This PR addresses the issue where the library fails to retrieve preview URLs for RAW images from GR II and GR III cameras due to camera API limitations:
- GR II doesn't support thumbnails for RAW or VIDEO files.
- GR III doesn't support 'xs' size for RAW or VIDEO files.


## Workaround Solution:
- For GR II thumbnail, use `?size=view` query parameter instead of `?size=thumb`.
  - Consequence: Increased file size, 60-100KB (instead of 5-7KB)
- For GR III XS sized preview image, use `?size=view` query parameter instead of `?size=xs`.
  - Consequence: Significantly reduced resolution, 0.3MP (instead of 2.5MP)

**Note:** 
- This workaround is applied to RAW files only.
- JPG resized images remain unaffected.

## Changes
- Updated `getResizedPhotoURL` method in `src/adapters/gr2/GR2Adapter.ts` and `src/adapters/gr3/GR3Adapter.ts` to use the `?size=view` query parameter for unsupported preview sizes on these camera models.