### PR TITLE
Fix/RCC-31 Increase getMediaList() Timeout to Support Large Media Libraries

### DIFF
--- a/example/src/hooks/useEventListener.ts
+++ b/example/src/hooks/useEventListener.ts
@@ -1,4 +1,4 @@
-import EventEmitter from 'events';
+import EventEmitter from 'eventemitter3';
 import { useEffect } from 'react';
 
 export const useEventListener = (

--- a/package.json
+++ b/package.json
@@ -190,6 +190,7 @@
   },
   "dependencies": {
     "axios": "^1.13.2",
+    "eventemitter3": "^5.0.4",
     "events": "^3.3.0"
   },
   "types": "./lib/typescript/commonjs/src/index.d.ts"

--- a/src/adapters/gr2/GR2Adapter.ts
+++ b/src/adapters/gr2/GR2Adapter.ts
@@ -31,6 +31,7 @@ export type { IRicohCameraController, IDeviceInfo, ICaptureSettings };
 class GR2Adapter extends EventEmitter implements IRicohCameraController {
   private readonly BASE_URL = 'http://192.168.0.1';
   private readonly REQUEST_TIMEOUT_MS = 1500;
+  private readonly REQUEST_MEDIA_LIST_TIMEOUT_MS = 15_000;
   private readonly POLLING_INTERVAL_MS = 2000;
   private readonly CONNECTION_HEALTH_OPTIONS: ConnectionHealthOptions = {
     maxConsecutiveFailures: 5,
@@ -292,7 +293,9 @@ class GR2Adapter extends EventEmitter implements IRicohCameraController {
   // #region Media Files: Photos & Videos
 
   async getMediaList(): Promise<IMediaList> {
-    const response = await this._apiClient.get('/v1/photos');
+    const response = await this._apiClient.get('/v1/photos', {
+      timeout: this.REQUEST_MEDIA_LIST_TIMEOUT_MS,
+    });
     if (response.data.errCode === 200) {
       return response.data;
     }

--- a/src/adapters/gr2/GR2Adapter.ts
+++ b/src/adapters/gr2/GR2Adapter.ts
@@ -1,5 +1,5 @@
 import axios, { type AxiosInstance } from 'axios';
-import { EventEmitter } from 'events';
+import EventEmitter from 'eventemitter3';
 import { CameraEvents } from '../../core/enums/CameraEvents';
 import {
   ConnectionHealthMonitor,

--- a/src/adapters/gr3/GR3Adapter.ts
+++ b/src/adapters/gr3/GR3Adapter.ts
@@ -32,6 +32,7 @@ export type { IRicohCameraController, IDeviceInfo, ICaptureSettings };
 class GR3Adapter extends EventEmitter implements IRicohCameraController {
   private readonly BASE_URL = 'http://192.168.0.1';
   private readonly REQUEST_TIMEOUT_MS = 1500;
+  private readonly REQUEST_MEDIA_LIST_TIMEOUT_MS = 15_000;
   private readonly POLLING_INTERVAL_MS = 2000;
   private readonly CONNECTION_HEALTH_OPTIONS: ConnectionHealthOptions = {
     maxConsecutiveFailures: 5,
@@ -293,7 +294,9 @@ class GR3Adapter extends EventEmitter implements IRicohCameraController {
   // #region Media Files: Photos & Videos
 
   async getMediaList(): Promise<IMediaList> {
-    const response = await this._apiClient.get('/v1/photos');
+    const response = await this._apiClient.get('/v1/photos', {
+      timeout: this.REQUEST_MEDIA_LIST_TIMEOUT_MS,
+    });
     if (response.data.errCode === 200) {
       return response.data;
     }

--- a/src/adapters/gr3/GR3Adapter.ts
+++ b/src/adapters/gr3/GR3Adapter.ts
@@ -1,5 +1,5 @@
 import axios, { type AxiosInstance } from 'axios';
-import { EventEmitter } from 'events';
+import EventEmitter from 'eventemitter3';
 import { CameraEvents } from '../../core/enums/CameraEvents';
 import {
   ConnectionHealthMonitor,

--- a/src/core/interfaces/IRicohCameraController.ts
+++ b/src/core/interfaces/IRicohCameraController.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from 'events';
+import EventEmitter from 'eventemitter3';
 import type { IDeviceInfo } from './IDeviceInfo';
 import type { ICaptureSettings } from './ICaptureSettings';
 import type { PhotoSize } from '../enums/PhotoSize';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,5 @@
 import axios, { type AxiosInstance } from 'axios';
-import { EventEmitter } from 'events';
+import EventEmitter from 'eventemitter3';
 import { CameraEvents } from './core/enums/CameraEvents';
 export { CameraEvents }; // Explicitly import and re-export it
 import type {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7537,6 +7537,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eventemitter3@npm:^5.0.4":
+  version: 5.0.4
+  resolution: "eventemitter3@npm:5.0.4"
+  checksum: bcbd2c3a9d2553c2289623ede8aab474d5c92bcbf18e5fe76f0e550c2b7801afb5a4351c7f11e8ee2379cca1ee48316aeb98fc3b946b7dd1f47a4c1ee8c4dcf2
+  languageName: node
+  linkType: hard
+
 "events@npm:^3.3.0":
   version: 3.3.0
   resolution: "events@npm:3.3.0"
@@ -12630,6 +12637,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-native-safe-area-context@npm:^5.7.0":
+  version: 5.7.0
+  resolution: "react-native-safe-area-context@npm:5.7.0"
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+  checksum: 0d831f4dc64e8453c67c095fe02d68ccf21b808c6338ef6a4db1cfacf3167956b682db40308a3f3152e59e9a5203b025f4bf28c2968c95e3afa22d9f52062ee0
+  languageName: node
+  linkType: hard
+
 "react-native-web@npm:^0.21.2":
   version: 0.21.2
   resolution: "react-native-web@npm:0.21.2"
@@ -13079,6 +13096,7 @@ __metadata:
     react-dom: 19.2.3
     react-native: 0.81.5
     react-native-builder-bob: ^0.40.17
+    react-native-safe-area-context: ^5.7.0
     react-native-web: ^0.21.2
     react-native-webview: ^13.16.0
   languageName: unknown
@@ -13103,6 +13121,7 @@ __metadata:
     eslint-plugin-ft-flow: ^3.0.11
     eslint-plugin-prettier: ^5.5.5
     eslint-plugin-react: ^7.37.5
+    eventemitter3: ^5.0.4
     events: ^3.3.0
     globals: ^16.5.0
     jest: ^30.2.0


### PR DESCRIPTION
## Summary
This PR increases the timeout value used by getMediaList() to prevent premature request failures when retrieving media from cameras containing large photo libraries. Cameras with several thousand images routinely exceed the previous 1500ms timeout, causing the API call to fail even though the device remains responsive.

## Problem
The existing hardcoded timeout of 1500ms is insufficient for cameras with large storage libraries. When the media list is large, the camera requires more time to process and return the full dataset. As a result, the request times out before completion.

## Changes
- Updated `src/adapters/gr2/GR2Adapter.ts` and `src/adapters/gr3/GR3Adapter.ts` to change the timeout value for `getMediaList()` from 1,500ms to 15,000ms.
- Installed `eventemitter3` to replace the native Node `events` module to ensure full RN compatibility and better performance.